### PR TITLE
Fix navigation bar animation in interactive pop

### DIFF
--- a/DevsignNavigationTransitions/Interactive Transition/PhotoDetailInteractiveDismissTransition.swift
+++ b/DevsignNavigationTransitions/Interactive Transition/PhotoDetailInteractiveDismissTransition.swift
@@ -88,6 +88,12 @@ public class PhotoDetailInteractiveDismissTransition: NSObject {
 		let transitionContext = self.transitionContext!
 		let backgroundAnimation = self.backgroundAnimation!
 
+        if didCancel {
+            transitionContext.cancelInteractiveTransition()
+        } else {
+            transitionContext.finishInteractiveTransition()
+        }
+
 		// The cancel and complete animations have different timing values.
 		// I dialed these in on-device using SwiftTweaks.
 		let completionDuration: Double
@@ -125,11 +131,6 @@ public class PhotoDetailInteractiveDismissTransition: NSObject {
 			self?.toDelegate?.transitionDidEnd()
 			self?.fromDelegate.transitionDidEnd()
 
-			if didCancel {
-				transitionContext.cancelInteractiveTransition()
-			} else {
-				transitionContext.finishInteractiveTransition()
-			}
 			transitionContext.completeTransition(!didCancel)
 			self?.transitionContext = nil
 		}


### PR DESCRIPTION
`cancelInteractiveTransition`/`finishInteractiveTransition` should be called when the interactive portion of the transition end before the non-interactive animations begin. That way, the navigation bar animates smoothly alongside the non-interactive animation. Currently, it does not animate during that part and abruptly changes shape when the transition ends.

Reproduce the issue: Start an interactive transition, release and complete after only a *brief* pan.